### PR TITLE
Added "ObjectGUID" field to ObjectVersion object 

### DIFF
--- a/Libraries/MFaaP.MFWSClient/MFWSStructs.cs
+++ b/Libraries/MFaaP.MFWSClient/MFWSStructs.cs
@@ -754,7 +754,12 @@ namespace MFaaP.MFWSClient
         /// Based on M-Files API.
         /// </summary>
         public bool VisibleAfterOperation { get; set; }
-        
+
+        /// <summary>
+        /// Based on M-Files API.
+        /// </summary>
+        public string ObjectGUID { get; set; }
+
     }
 
     


### PR DESCRIPTION
REST API returns "ObjectGUID" but it is not included in wrapper object.