### PR TITLE
Bugfix for incorrect paramater type in snippet for AutomaticStateTransitionTrigger

### DIFF
--- a/Visual Studio Snippets/Vault Application Framework/Snippets/CSharp/MFilesVAF/MFVAFWorkflows.snippet
+++ b/Visual Studio Snippets/Vault Application Framework/Snippets/CSharp/MFilesVAF/MFVAFWorkflows.snippet
@@ -216,7 +216,7 @@ public bool $MethodName$(StateEnvironment env, out string message)
 /// <remarks>The default next state Id is available in <see cref="MFiles.VAF.Common.StateEnvironment.InitialNextStateID"/>, but this can be
 /// altered to any valid transition by setting <see cref="nextState"/> to a different state Id.</remarks>
 [AutomaticStateTransitionTrigger("$Alias$")]
-public bool $MethodName$(StateEnvironment env, out int nextState)
+public bool $MethodName$(StateTransitionEnvironment env, out int nextState)
 {
 	$end$
 	throw new System.NotImplementedException();


### PR DESCRIPTION
Small bug in the VAF snippet for AutomaticStateTransitionTrigger. Parameter current generated in template is  StateEnvironment env, it should be StateTransitionEnvironment env